### PR TITLE
Replace deprecated Dreamcast int types

### DIFF
--- a/Makefile.dc
+++ b/Makefile.dc
@@ -3,9 +3,9 @@
 # DreamHAL memory routines and replacements; threading updates.
 # Set GL=1 to build the GLdc-enabled archive.
 
-CC := sh-elf-gcc
-AR := sh-elf-gcc-ar
-LD := sh-elf-gcc
+CC := kos-cc
+AR := kos-ar
+LD := kos-ld
 ARFLAGS ?= rcs
 
 # ------------------------------ Build variant ------------------------------
@@ -24,7 +24,7 @@ KOS_CFLAGS += -Isrc/video -Isrc/video/dc -DNO_SIGNAL_H -DENABLE_DC
 # Ensure Dreamcast platform config and backend are selected
 KOS_CFLAGS += -D__DREAMCAST__ -DSDL_VIDEO_DRIVER_DREAMCAST
 
-CFLAGS   := $(KOS_CFLAGS) -Wimplicit-function-declaration $(DEFS) -Iinclude
+CFLAGS   := -Wimplicit-function-declaration $(DEFS) -Iinclude
 DEPFLAGS := -MMD -MP
 
 # ------------------------------ Sources ------------------------------

--- a/src/audio/dc/aica/SDL_dcaudio.c
+++ b/src/audio/dc/aica/SDL_dcaudio.c
@@ -120,9 +120,9 @@ static void DCAUD_WaitAudio(_THIS)
 
 static __inline__ void SDL_DC_spu_memload_stereo8(int leftpos,int rightpos,void *__restrict__ src0,size_t size)
 {
-	uint8 *src = src0;
-	uint32 *left  = (uint32*)(leftpos + SDL_DC_SPU_RAM_BASE);
-	uint32 *right = (uint32*)(rightpos+ SDL_DC_SPU_RAM_BASE);
+	Uint8 *src = src0;
+	Uint32 *left  = (Uint32*)(leftpos + SDL_DC_SPU_RAM_BASE);
+	Uint32 *right = (Uint32*)(rightpos+ SDL_DC_SPU_RAM_BASE);
 	unsigned old1,old2;
 	SDL_DC_G2_LOCK(old1, old2);
 	size >>= 5;
@@ -163,9 +163,9 @@ static __inline__ void SDL_DC_spu_memload_stereo8(int leftpos,int rightpos,void 
 
 static __inline__ void SDL_DC_spu_memload_stereo16(int leftpos,int rightpos,void *__restrict__ src0,size_t size)
 {
-	uint16 *src = src0;
-	uint32 *left  = (uint32*)(leftpos + SDL_DC_SPU_RAM_BASE);
-	uint32 *right = (uint32*)(rightpos+ SDL_DC_SPU_RAM_BASE);
+	Uint16 *src = src0;
+	Uint32 *left  = (Uint32*)(leftpos + SDL_DC_SPU_RAM_BASE);
+	Uint32 *right = (Uint32*)(rightpos+ SDL_DC_SPU_RAM_BASE);
 	unsigned old1,old2;
 	SDL_DC_G2_LOCK(old1, old2);
 	size >>= 5;
@@ -196,9 +196,9 @@ static __inline__ void SDL_DC_spu_memload_stereo16(int leftpos,int rightpos,void
 	SDL_DC_G2_FIFO_WAIT();
 }
 
-static __inline__ void SDL_DC_spu_memload_mono(uint32 dst, uint32 *__restrict__ src,size_t size)
+static __inline__ void SDL_DC_spu_memload_mono(Uint32 dst, Uint32 *__restrict__ src,size_t size)
 {
-	register uint32 *dat  = (uint32*)(dst + SDL_DC_SPU_RAM_BASE);
+	register Uint32 *dat  = (Uint32*)(dst + SDL_DC_SPU_RAM_BASE);
 
 	unsigned old1,old2;
 	SDL_DC_G2_LOCK(old1, old2);
@@ -233,7 +233,7 @@ static void DCAUD_PlayAudio(_THIS)
 	this->hidden->nextbuf^=1;
 	/* Write the audio data, checking for EAGAIN on broken audio drivers */
 	if (spec->channels==1) {
-		SDL_DC_spu_memload_mono(this->hidden->leftpos+offset,(uint32 *__restrict__)this->hidden->mixbuf,this->hidden->mixlen);
+		SDL_DC_spu_memload_mono(this->hidden->leftpos+offset,(Uint32 *__restrict__)this->hidden->mixbuf,this->hidden->mixlen);
 	} else {
 		offset>>=1;
 		if ((this->spec.format&255)==8) {

--- a/src/joystick/dc/SDL_sysjoystick.c
+++ b/src/joystick/dc/SDL_sysjoystick.c
@@ -215,10 +215,10 @@ const char* shiftKeyboardLayout[VK_ROWS][VK_COLS] = {
     {"Z", "X", "C", "V", "B", "N", "M", "<", ">", "?", "SPC", "", "","ENTER"}
 };
 
-void bfont_draw_box(void *buffer, uint32 bufwidth, int x, int y, int width, int height, uint8 opaque, uint32 color) {
+void bfont_draw_box(void *buffer, Uint32 bufwidth, int x, int y, int width, int height, Uint8 opaque, Uint32 color) {
     int i, j;
-    uint32 old_fg = bfont_set_foreground_color(color);
-    uint32 *buf = (uint32*)buffer;
+    Uint32 old_fg = bfont_set_foreground_color(color);
+    Uint32 *buf = (Uint32*)buffer;
 
     // Draw top and bottom edges
     for (i = 0; i < width; ++i) {
@@ -249,9 +249,9 @@ void drawVirtualKeyboard() {
     int line_spacing = 20;
     int width = 640;
     int key_spacing = 15;  // Space between keys
-    uint8 opaque = 1;      // Set opaque to true for drawing the box
-    uint32 normalColor = 0x000FFF; // Color for the highlight box (e.g., white)
-    uint32 highlightColor = 0x000000; // Normal key color (e.g., black)
+    Uint8 opaque = 1;      // Set opaque to true for drawing the box
+    Uint32 normalColor = 0x000FFF; // Color for the highlight box (e.g., white)
+    Uint32 highlightColor = 0x000000; // Normal key color (e.g., black)
 
     for (int i = 0; i < VK_ROWS; ++i) {
         const char **row = (shiftActive) ? shiftKeyboardLayout[i] : keyboardLayout[i];

--- a/src/timer/dc/SDL_systimer.c
+++ b/src/timer/dc/SDL_systimer.c
@@ -51,11 +51,11 @@ void SDL_StartTicks(void)
 
 Uint32 SDL_GetTicks(void)
 {
-    uint32 s, ms;
-	uint64 msec;
+    Uint32 s, ms;
+	Uint64 msec;
 
 	timer_ms_gettime(&s, &ms);
-	msec = (((uint64)s) * ((uint64)1000)) + ((uint64)ms);
+	msec = (((Uint64)s) * ((Uint64)1000)) + ((Uint64)ms);
 
 	return (Uint32)msec;
 }


### PR DESCRIPTION
Replaces variables types originally provided by KOS' `<arch/types.h>` with the standard versions used throughout SDL. Additionally, a small cleanup to the dc makefile to use KOS' build wrappers.